### PR TITLE
Fix bug in Deployment.Strategy enum deserialization

### DIFF
--- a/client/src/main/scala/skuber/json/ext/format/package.scala
+++ b/client/src/main/scala/skuber/json/ext/format/package.scala
@@ -65,7 +65,7 @@ package object format {
   )(Deployment.RollingUpdate.apply _, unlift(Deployment.RollingUpdate.unapply))
   
   implicit val depStrategyFmt: Format[Deployment.Strategy] =  (
-    (JsPath \ "type").formatEnum(Deployment.StrategyType) and
+    (JsPath \ "type").formatEnum(Deployment.StrategyType, Some(Deployment.StrategyType.RollingUpdate)) and
     (JsPath \ "rollingUpdate").formatNullable[Deployment.RollingUpdate]
   )(Deployment.Strategy.apply _, unlift(Deployment.Strategy.unapply))
   

--- a/client/src/test/scala/skuber/ext/DeploymentSpec.scala
+++ b/client/src/test/scala/skuber/ext/DeploymentSpec.scala
@@ -62,6 +62,11 @@ class DeploymentSpec extends Specification {
         {"key": "tier","operator": "In", "values": ["frontend"]}
       ]
     },
+    "strategy": {
+      "rollingUpdate": {
+        "maxUnavailable": 1
+      }
+    },
     "template": {
       "metadata": {
         "labels": {


### PR DESCRIPTION
@coryfklein The test exposes the bug and validates the fix

I tried to make the broader fix of changing `formatEnum()`'s second param from `Option[E#Value]` to just `E#Value` because all but one caller did have a default. But for one caller (WatchEvent's `EventType`) it was not clear what the default should be, so I abandoned that.